### PR TITLE
feat: ハングアクションを追加

### DIFF
--- a/src/medipro/HangWire.java
+++ b/src/medipro/HangWire.java
@@ -1,0 +1,56 @@
+package medipro;
+
+public class HangWire {
+  private Vector2 start;
+
+  private Vector2 direction;
+  private Vector2 launched;
+  private double progress;
+  private boolean isHanged = false;
+
+  public HangWire(Vector2 start, Vector2 direction) {
+    this.start = start;
+    this.direction = direction;
+    this.launched = start;
+  }
+
+  public Vector2 getStart() {
+    return start;
+  }
+
+  public void setStart(Vector2 start) {
+    this.start = start;
+  }
+
+  public Vector2 getDirection() {
+    return direction;
+  }
+
+  public double getProgress() {
+    return progress;
+  }
+
+  public void setProgress(double progress) {
+    this.progress = progress;
+  }
+
+  public Vector2 getEnd(double progress) {
+    return launched.add(direction.mul(progress));
+  }
+
+  public Vector2 getEnd() {
+    return getEnd(progress);
+  }
+
+  public Vector2 getLaunched() {
+    return launched;
+  }
+
+  public boolean isHanged() {
+    return isHanged;
+  }
+
+  public void setHanged(boolean isHanging) {
+    this.isHanged = isHanging;
+  }
+}

--- a/src/medipro/Vector2.java
+++ b/src/medipro/Vector2.java
@@ -1,0 +1,56 @@
+package medipro;
+
+public class Vector2 {
+  private double x;
+  private double y;
+
+  public Vector2(double x, double y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public void setX(double x) {
+    this.x = x;
+  }
+
+  public void setY(double y) {
+    this.y = y;
+  }
+
+  public Vector2 add(Vector2 other) {
+    return new Vector2(x + other.x, y + other.y);
+  }
+
+  public Vector2 sub(Vector2 other) {
+    return new Vector2(x - other.x, y - other.y);
+  }
+
+  public Vector2 mul(double scalar) {
+    return new Vector2(x * scalar, y * scalar);
+  }
+
+  public Vector2 div(double scalar) {
+    return new Vector2(x / scalar, y / scalar);
+  }
+
+  public Vector2 normalize() {
+    double n = norm();
+    return new Vector2(x / n, y / n);
+  }
+
+  public double norm() {
+    return Math.sqrt(x * x + y * y);
+  }
+
+  public double norm2() {
+    return x * x + y * y;
+  }
+}

--- a/src/medipro/stage/StageView.java
+++ b/src/medipro/stage/StageView.java
@@ -10,6 +10,7 @@ import javax.swing.JPanel;
 import javax.swing.Timer;
 
 import medipro.Entity;
+import medipro.Vector2;
 import medipro.World;
 
 public class StageView extends JPanel implements MouseListener {
@@ -65,6 +66,15 @@ public class StageView extends JPanel implements MouseListener {
                     (int) entity.getPosY() + entity.getHeight());
             g.drawLine((int) entity.getPosX() + entity.getWidth(), (int) entity.getPosY(), (int) entity.getPosX(),
                     (int) entity.getPosY() + entity.getHeight());
+        }
+
+        // ハングワイヤーの描画
+        if (model.getHangWire() != null) {
+            g.setColor(Color.PINK);
+            Vector2 hangWireStart = model.getHangWire().getStart();
+            Vector2 hangWireEnd = model.getHangWire().getEnd();
+            g.drawLine((int) hangWireStart.getX(), (int) hangWireStart.getY(), (int) hangWireEnd.getX(),
+                    (int) hangWireEnd.getY());
         }
 
         // entity data


### PR DESCRIPTION
## 変更点
- ハングアクションを追加
  - h,kキーでそれぞれ左右の上45度にワイヤーを飛ばす
  - ワイヤーが壁に付いたらバネ定数に応じた張力がプレイヤーにかかる
  - jキーでワイヤー解除

## 備考
- 現在は長さに比例する張力がかかるが、ゲーム性に応じて長さによらない張力がかかるように適宜変更したほうがいい